### PR TITLE
fix: missing angle bracket flip and fix ltr word reverse when using b…

### DIFF
--- a/src/rtlUtils.js
+++ b/src/rtlUtils.js
@@ -480,6 +480,10 @@ function fixArabicTextUsingReplace(text) {
 	if (text.startsWith('.')) {
 		text = text.slice(1);
 	}
+
+	if (!containsRTL(text))
+		return text;
+
 	text = text
 		.replace(/\(/g, 'TEMP_OPEN_PAREN')
 		.replace(/\)/g, '(')
@@ -491,9 +495,11 @@ function fixArabicTextUsingReplace(text) {
 
 		.replace(/\{/g, 'TEMP_OPEN_CURLY')
 		.replace(/\}/g, '{')
-		.replace(/TEMP_OPEN_CURLY/g, '}');
+		.replace(/TEMP_OPEN_CURLY/g, '}')
 
-
+		.replace(/</g, 'TEMP_OPEN_ANGLE')
+		.replace(/>/g, '<')
+		.replace(/TEMP_OPEN_ANGLE/g, '>');
 
 	return text;
 }


### PR DESCRIPTION
Great job you got there! It's hard to have original pdfmake to support RTL until I found your work. But after some experiment I found that you miss the angle bracket to flip (<>) and it should not flip LTR word bracket when it's mixed. And I'm adding new function to fix LTR word reverse when inside a bracket. You may want to check it first. Regard